### PR TITLE
feat: Add user profile and authentication fixes

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,13 +21,37 @@ class SessionsController < ApplicationController
       end
 
       # OmniAuth login
-      user = User.find_or_initialize_by(provider: auth_hash.provider, uid: auth_hash.uid)
-
-      # Always update these fields when logging in from OmniAuth
-      user.email_address = auth_hash.info.email
-      user.password ||= generate_compliant_password # only assign if password missing
-
-      user.save! # raises validation errors if something is wrong
+      # First, try to find user by provider/uid (existing OAuth user)
+      user = User.find_by(provider: auth_hash.provider, uid: auth_hash.uid)
+      
+      # If not found, check if a user exists with this email (account merging)
+      if user.nil?
+        user = User.find_by(email_address: auth_hash.info.email)
+        
+        # If user exists with this email, link the OAuth credentials
+        if user
+          user.provider = auth_hash.provider
+          user.uid = auth_hash.uid
+          # Don't touch password - keep existing password for email/password login
+          # Don't overwrite username/photo for existing accounts
+          user.save!(validate: false) # Skip validations to avoid password issues
+        else
+          # New user - create from scratch
+          user = User.new(
+            provider: auth_hash.provider,
+            uid: auth_hash.uid,
+            email_address: auth_hash.info.email,
+            password: generate_compliant_password,
+            username: auth_hash.info.name || auth_hash.info.email.split("@").first,
+            photo_url: auth_hash.info.image
+          )
+          user.save!
+        end
+      else
+        # Existing OAuth user - just update email
+        user.email_address = auth_hash.info.email
+        user.save!(validate: false)
+      end
 
       start_new_session_for(user)
       redirect_to(after_authentication_url, notice: "Signed in successfully!")

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,8 +7,45 @@ class UsersController < ApplicationController
     @user = User.new
   end
 
+  def profile
+    @user = current_user
+  end
+
+  def update_profile
+    @user = current_user
+    
+    # Handle profile photo upload
+    if params[:user][:profile_photo].present?
+      @user.profile_photo.attach(params[:user][:profile_photo])
+      # Clear photo_url so the uploaded photo takes precedence
+      @user.photo_url = nil
+    end
+    
+    if @user.update(profile_params)
+      redirect_to profile_users_path, notice: "Profile updated successfully!"
+    else
+      render :profile, status: :unprocessable_entity
+    end
+  end
+
   def create
+    # Check if a user with this email already exists
+    existing_user = User.find_by(email_address: params[:user][:email_address]&.strip&.downcase)
+    
+    if existing_user && existing_user.provider.present?
+      # User signed up with OAuth (Google), prompt them to use that method
+      flash[:alert] = "An account with this email already exists. Please sign in with Google instead."
+      redirect_to new_session_path
+      return
+    end
+    
     @user = User.new(user_params)
+    
+    # Handle profile photo upload
+    if params[:user][:profile_photo].present?
+      @user.profile_photo.attach(params[:user][:profile_photo])
+    end
+    
     if @user.save
       redirect_to(new_session_path, notice: "Account created successfully! Please sign in.")
     else
@@ -19,6 +56,10 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:email_address, :password, :password_confirmation)
+    params.require(:user).permit(:username, :email_address, :password, :password_confirmation, :profile_photo)
+  end
+
+  def profile_params
+    params.require(:user).permit(:username, :profile_photo)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,16 +3,19 @@
 class User < ApplicationRecord
   has_secure_password
   validates :email_address, uniqueness: true
+  validates :username, presence: true
   validates :password,
     length: { minimum: 12, message: "must be at least 12 characters long" },
     format: {
       with: /\A(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[[:^alnum:]])/,
       message: "must include at least one lowercase letter, one uppercase letter, one digit, and one special character",
-    }
+    },
+    if: :password_digest_changed?
   has_many :sessions, dependent: :destroy
   has_many :locations
   has_many :reviews
   has_many_attached :pictures
+  has_one_attached :profile_photo
   has_and_belongs_to_many :favorite_locations, class_name: "Location", join_table: "favorites"
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,7 @@
           <% if current_user %>
             <%= link_to "Search Locations", root_path, class: "transition w-full sm:w-auto py-2 px-4 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg hover:bg-gray-100 focus:z-10 focus:ring-4 focus:ring-gray-100" %>
             <%= link_to "Add Location", new_location_path, class: "transition w-full sm:w-auto py-2 px-4 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg hover:bg-gray-100 focus:z-10 focus:ring-4 focus:ring-gray-100" %>
+            <%= link_to "My Profile", profile_users_path, class: "transition w-full sm:w-auto py-2 px-4 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg hover:bg-gray-100 focus:z-10 focus:ring-4 focus:ring-gray-100" %>
             <%= link_to "Logout", session_path, data: { "turbo-method": :delete }, class: "transition w-full sm:w-auto py-2 px-4 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 focus:z-10 focus:ring-4 focus:ring-gray-100" %>
           <% else %>
             <%= link_to "Login", new_session_path, class: "transition w-full sm:w-auto py-2 px-4 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 focus:z-10 focus:ring-4 focus:ring-gray-100" %>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -1,6 +1,21 @@
 <article class="p-4 bg-white border border-gray-200 rounded-lg shadow-sm space-y-2">
-  <div class="flex sm:flex-row flex-col justify-between items-start sm:items-center sm:gap-4 gap-2">
-    <h3 class="text-xl text-gray-900 font-medium truncate"><%= review.user.email_address %></h3>
+  <div class="flex justify-between items-start gap-4">
+    <div class="flex items-center gap-3">
+      <!-- Profile Photo -->
+      <div class="flex-shrink-0">
+        <% if review.user.photo_url.present? %>
+          <%= image_tag review.user.photo_url, class: "w-10 h-10 rounded-full object-cover", alt: review.user.username %>
+        <% elsif review.user.profile_photo.attached? %>
+          <%= image_tag review.user.profile_photo, class: "w-10 h-10 rounded-full object-cover", alt: review.user.username %>
+        <% else %>
+          <div class="w-10 h-10 rounded-full bg-blue-500 flex items-center justify-center">
+            <span class="text-sm font-bold text-white"><%= review.user.username[0].upcase %></span>
+          </div>
+        <% end %>
+      </div>
+      <!-- Username -->
+      <h3 class="text-xl text-gray-900 font-medium"><%= review.user.username %></h3>
+    </div>
     <div class="flex gap-3 flex-wrap">
       <% if current_user == review.user %>
         <button data-modal-target="edit-review-modal-<%= review.id %>" data-modal-toggle="edit-review-modal-<%= review.id %>" type="button" class="text-gray-700 text-sm text-nowrap hover:underline underline-offset-4">Edit Review</button>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -21,6 +21,10 @@
         </div>
       <% end %>
       <div class="space-y-2">
+        <%= form.label :username, class: "block font-medium mb-3" %>
+        <%= form.text_field :username, placeholder: "Choose a username", required: true, class: "text-sm w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+      </div>
+      <div class="space-y-2">
         <%= form.label :email_address, class: "block font-medium mb-3" %>
         <%= form.email_field :email_address, placeholder: "Enter your email address", class: "text-sm w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
       </div>
@@ -31,6 +35,11 @@
       <div class="space-y-2">
         <%= form.label :password_confirmation, class: "block font-medium mb-3" %>
         <%= form.password_field :password_confirmation, placeholder: "Confirm your password", class: "text-sm w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+      </div>
+      <div class="space-y-2">
+        <%= form.label :profile_photo, "Profile Photo (optional)", class: "block font-medium mb-3" %>
+        <%= form.file_field :profile_photo, accept: "image/*", class: "text-xs text-gray-600 w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300 file:mr-4 file:py-1 file:px-3 file:rounded file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100" %>
+        <p class="text-xs text-gray-500">Upload a profile picture (JPG, PNG, etc.)</p>
       </div>
       <div class="w-full text-center">
         <%= form.submit "Sign Up", class: "w-full text-white rounded-md bg-blue-700 hover:bg-blue-800 hover:cursor-pointer py-2 font-medium" %>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -1,0 +1,130 @@
+<% content_for :title, "My Profile" %>
+
+<div class="max-w-3xl mx-auto p-6">
+  <div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+    <!-- Header -->
+    <div class="bg-gradient-to-r from-blue-500 to-blue-600 px-6 py-8">
+      <h1 class="text-2xl font-bold text-white">My Profile</h1>
+    </div>
+
+    <!-- Profile Content -->
+    <div class="p-6 space-y-6">
+      <!-- Profile Photo and Username -->
+      <div class="flex items-center gap-6">
+        <div class="flex-shrink-0">
+          <% if @user.photo_url.present? %>
+            <%= image_tag @user.photo_url, class: "w-24 h-24 rounded-full object-cover border-4 border-white shadow-lg", alt: @user.username %>
+          <% elsif @user.profile_photo.attached? %>
+            <%= image_tag @user.profile_photo, class: "w-24 h-24 rounded-full object-cover border-4 border-white shadow-lg", alt: @user.username %>
+          <% else %>
+            <div class="w-24 h-24 rounded-full bg-blue-500 flex items-center justify-center border-4 border-white shadow-lg">
+              <span class="text-3xl font-bold text-white"><%= @user.username[0].upcase %></span>
+            </div>
+          <% end %>
+        </div>
+        <div>
+          <h2 class="text-2xl font-bold text-gray-900"><%= @user.username %></h2>
+          <p class="text-gray-600 mt-1"><%= @user.email_address %></p>
+        </div>
+      </div>
+
+      <!-- Divider -->
+      <hr class="border-gray-200">
+
+      <!-- Edit Profile Form -->
+      <div class="space-y-4">
+        <h3 class="text-lg font-semibold text-gray-900">Edit Profile</h3>
+        
+        <%= form_with model: @user, url: update_profile_users_path, method: :patch, local: true, class: "space-y-4" do |f| %>
+          <% if @user.errors.any? %>
+            <div class="rounded-md bg-red-50 p-4 text-red-700">
+              <p class="font-semibold mb-2"><%= pluralize(@user.errors.count, "error") %> prevented this profile from being saved:</p>
+              <ul class="list-disc pl-5">
+                <% @user.errors.each do |error| %>
+                  <li><%= error.full_message %></li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+
+          <div class="space-y-2">
+            <%= f.label :username, class: "block text-sm font-medium text-gray-700" %>
+            <%= f.text_field :username, class: "text-sm w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+          </div>
+
+          <div class="space-y-2">
+            <%= f.label :profile_photo, "Profile Photo", class: "block text-sm font-medium text-gray-700" %>
+            <%= f.file_field :profile_photo, accept: "image/*", class: "text-xs text-gray-600 w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300 file:mr-4 file:py-1 file:px-3 file:rounded file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100" %>
+            <p class="text-xs text-gray-500">Upload a new profile picture to replace the current one</p>
+          </div>
+
+          <div>
+            <%= f.submit "Update Profile", class: "px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium transition-colors cursor-pointer" %>
+          </div>
+        <% end %>
+      </div>
+
+      <!-- Divider -->
+      <hr class="border-gray-200">
+
+      <!-- Account Information -->
+      <div class="space-y-4">
+        <h3 class="text-lg font-semibold text-gray-900">Account Information</h3>
+        
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="space-y-1">
+            <p class="text-sm font-medium text-gray-500">Username</p>
+            <p class="text-base text-gray-900"><%= @user.username %></p>
+          </div>
+
+          <div class="space-y-1">
+            <p class="text-sm font-medium text-gray-500">Email</p>
+            <p class="text-base text-gray-900"><%= @user.email_address %></p>
+          </div>
+
+          <div class="space-y-1">
+            <p class="text-sm font-medium text-gray-500">Member Since</p>
+            <p class="text-base text-gray-900"><%= @user.created_at.strftime("%B %d, %Y") %></p>
+          </div>
+
+          <% if @user.provider.present? %>
+            <div class="space-y-1">
+              <p class="text-sm font-medium text-gray-500">Sign-in Method</p>
+              <p class="text-base text-gray-900 capitalize"><%= @user.provider %></p>
+            </div>
+          <% end %>
+        </div>
+      </div>
+
+      <!-- Divider -->
+      <hr class="border-gray-200">
+
+      <!-- Activity Stats -->
+      <div class="space-y-4">
+        <h3 class="text-lg font-semibold text-gray-900">Activity</h3>
+        
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div class="bg-blue-50 rounded-lg p-4 text-center">
+            <p class="text-3xl font-bold text-blue-600"><%= @user.locations.count %></p>
+            <p class="text-sm text-gray-600 mt-1">Locations Added</p>
+          </div>
+
+          <div class="bg-green-50 rounded-lg p-4 text-center">
+            <p class="text-3xl font-bold text-green-600"><%= @user.reviews.count %></p>
+            <p class="text-sm text-gray-600 mt-1">Reviews Written</p>
+          </div>
+
+          <div class="bg-purple-50 rounded-lg p-4 text-center">
+            <p class="text-3xl font-bold text-purple-600"><%= @user.favorite_locations.count %></p>
+            <p class="text-sm text-gray-600 mt-1">Favorites</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Actions -->
+      <div class="flex gap-3 pt-4">
+        <%= link_to "Back", :back, class: "px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 font-medium transition-colors" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,12 @@ Rails.application.routes.draw do
   match "/auth/:provider/callback", to: "sessions#create", via: [:get, :post]
 
   resources :passwords, param: :token
-  resources :users, only: [:new, :create]
+  resources :users, only: [:new, :create] do
+    collection do
+      get :profile
+      patch :update_profile
+    end
+  end
   # resources :reviews
   #
   resources :locations do

--- a/db/migrate/20251207000843_add_username_and_photo_url_to_users.rb
+++ b/db/migrate/20251207000843_add_username_and_photo_url_to_users.rb
@@ -1,0 +1,19 @@
+class AddUsernameAndPhotoUrlToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :username, :string
+    add_column :users, :photo_url, :string
+    
+    # Set existing users' username to their email for now
+    reversible do |dir|
+      dir.up do
+        User.reset_column_information
+        User.find_each do |user|
+          user.update_column(:username, user.email_address)
+        end
+      end
+    end
+    
+    # Make username required
+    change_column_null :users, :username, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_06_215450) do
+ActiveRecord::Schema[8.0].define(version: 2025_12_07_000843) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -231,6 +231,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_06_215450) do
     t.datetime "updated_at", null: false
     t.string "provider"
     t.string "uid"
+    t.string "username", null: false
+    t.string "photo_url"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 


### PR DESCRIPTION
- Added username and profile photo under users
- If user signs up w/ email + pwd, set username + optional photo upload
- If user signs up w/ Google, take Google account name and photo
- Created profile page /users/profile for authenticated user
- Allow editing username and photo in profile page
- Reviews display photo and name instead of email.
- If user tries to sign in with Google with same email, merge accounts
- If user tries to sign up normally but has OAuth account, let them know